### PR TITLE
support drag drop folders to load files under those folders

### DIFF
--- a/UABEANext4/ViewModels/MainViewModel.cs
+++ b/UABEANext4/ViewModels/MainViewModel.cs
@@ -191,9 +191,17 @@ public partial class MainViewModel : ViewModelBase
     #endregion
 
     #region Menu items
-    public async Task OpenFiles(IEnumerable<string?> enumerable)
+    public async Task OpenFiles(IEnumerable<string?> paths)
     {
-        int totalCount = enumerable.Count();
+        var filePaths = new List<string>();
+        foreach (var path in paths)
+        {
+            if (File.Exists(path))
+                filePaths.Add(path);
+            if (Directory.Exists(path))
+                filePaths.AddRange(Directory.GetFiles(path, "*",  SearchOption.AllDirectories));
+        }
+        int totalCount = filePaths.Count();
         if (totalCount == 0)
         {
             return;
@@ -211,7 +219,7 @@ public partial class MainViewModel : ViewModelBase
             Workspace.ProgressValue = 0;
             int startLoadOrder = Workspace.NextLoadIndex;
             int currentCount = 0;
-            Parallel.ForEach(enumerable, options, (fileName, state, index) =>
+            Parallel.ForEach(filePaths, options, (fileName, state, index) =>
             {
                 if (fileName is not null)
                 {


### PR DESCRIPTION
Added support for loading files under dropped folders. There are some concerns...

1. Files are now checked for existence (where they previously weren't), this may have implications, although File.Open would require the file existing to begin with...
2. Folders load anything recursively, if you drag and drop your C drive.... good luck? should there be some level of protection against this?
3. If a path exists for both a folder and a file, they'll both be loaded. I don't believe this is an issue in standard unity applications.