### PR TITLE
Fix for batch export font and TextAsset

### DIFF
--- a/FontPlugin/ExportFontOption.cs
+++ b/FontPlugin/ExportFontOption.cs
@@ -65,7 +65,7 @@ public class ExportFontOption : IUavPluginOption
             var extension = isOtf ? ".otf" : ".ttf";
 
             var assetName = PathUtils.ReplaceInvalidPathChars(name);
-            var filePath = AssetNameUtils.GetAssetFileName(asset, assetName, extension);
+            var filePath = Path.Combine(dir, AssetNameUtils.GetAssetFileName(asset, assetName, extension));
 
             File.WriteAllBytes(filePath, byteData);
         }

--- a/TextAssetPlugin/ExportTextAssetPlugin.cs
+++ b/TextAssetPlugin/ExportTextAssetPlugin.cs
@@ -62,7 +62,7 @@ public class ExportTextAssetPlugin : IUavPluginOption
             var byteData = textBaseField["m_Script"].AsByteArray;
 
             var assetName = PathUtils.ReplaceInvalidPathChars(name);
-            var filePath = AssetNameUtils.GetAssetFileName(asset, assetName, ".txt");
+            var filePath = Path.Combine(dir, AssetNameUtils.GetAssetFileName(asset, assetName, ".txt"));
 
             File.WriteAllBytes(filePath, byteData);
         }


### PR DESCRIPTION
Before the fix, they were saved in the program’s folder instead of the directory specified in the dialog window.