### PR TITLE
Fix text color in Asset Info window, drag&drop support

### DIFF
--- a/UABEANext4/Themes/TabTheme.axaml
+++ b/UABEANext4/Themes/TabTheme.axaml
@@ -27,7 +27,7 @@
     <Setter Property="FontSize" Value="12" />
     <Setter Property="Height" Value="30" />
     <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
-    <Setter Property="Foreground" Value="#F0F0F0" />
+	<Setter Property="Foreground" Value="{DynamicResource DockThemeForegroundBrush}"/>
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="Margin" Value="0 0 0 0" />
     <Setter Property="Padding" Value="10 0" />
@@ -39,12 +39,12 @@
   </Style>
 
   <Style Selector="TabItem:focus">
-    <Setter Property="Foreground" Value="#33AEEA" />
+	<Setter Property="Foreground" Value="{DynamicResource DockThemeForegroundBrush}"/>
   </Style>
 
   <Style Selector="TabItem:selected">
-    <Setter Property="Foreground" Value="#F0F0F0" /> 
-    <Setter Property="Background" Value="{DynamicResource TabViewSelectedBackgroundBrush}" />
+	<Setter Property="Foreground" Value="{DynamicResource DockThemeForegroundBrush}" /> 
+    <Setter Property="Background" Value="{DynamicResource TabViewSelectedBackgroundBrush}"/>
     <Setter Property="Margin" Value="0 0 0 0" />
     <Setter Property="Padding" Value="10 0" />
   </Style>

--- a/UABEANext4/Views/Dialogs/AssetInfoView.axaml
+++ b/UABEANext4/Views/Dialogs/AssetInfoView.axaml
@@ -19,15 +19,7 @@
     <Grid.Resources>
       <uac:AssetTypeIconConverter x:Key="TypeTreeNodeConverter" />
     </Grid.Resources>
-     <TabControl Grid.Row="0">
-		 <TabControl.Styles>
-			 <Style Selector="TabItem">
-				 <Setter Property="Foreground" Value="{DynamicResource DockThemeForegroundBrush}"/>
-			 </Style>
-			 <Style Selector="TabItem:selected">
-				 <Setter Property="Foreground" Value="{DynamicResource DockThemeForegroundBrush}"/>
-			 </Style>
-		 </TabControl.Styles>
+    <TabControl Grid.Row="0">
       <TabItem Header="General Info">
         <ScrollViewer>
           <StackPanel Orientation="Vertical" Spacing="10">

--- a/UABEANext4/Views/Dialogs/AssetInfoView.axaml
+++ b/UABEANext4/Views/Dialogs/AssetInfoView.axaml
@@ -19,12 +19,15 @@
     <Grid.Resources>
       <uac:AssetTypeIconConverter x:Key="TypeTreeNodeConverter" />
     </Grid.Resources>
-    <TabControl Grid.Row="0">
-		  <TabControl.Styles>
-			  <Style Selector="TabItem">
-				  <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}"/>
-			  </Style>
-		  </TabControl.Styles>
+     <TabControl Grid.Row="0">
+			 <TabControl.Styles>
+				 <Style Selector="TabItem">
+					 <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}"/>
+				 </Style>
+				 <Style Selector="TabItem:selected">
+					 <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}"/>
+				 </Style>
+			 </TabControl.Styles>
       <TabItem Header="General Info">
         <ScrollViewer>
           <StackPanel Orientation="Vertical" Spacing="10">

--- a/UABEANext4/Views/Dialogs/AssetInfoView.axaml
+++ b/UABEANext4/Views/Dialogs/AssetInfoView.axaml
@@ -20,14 +20,14 @@
       <uac:AssetTypeIconConverter x:Key="TypeTreeNodeConverter" />
     </Grid.Resources>
      <TabControl Grid.Row="0">
-			 <TabControl.Styles>
-				 <Style Selector="TabItem">
-					 <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}"/>
-				 </Style>
-				 <Style Selector="TabItem:selected">
-					 <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}"/>
-				 </Style>
-			 </TabControl.Styles>
+		 <TabControl.Styles>
+			 <Style Selector="TabItem">
+				 <Setter Property="Foreground" Value="{DynamicResource DockThemeForegroundBrush}"/>
+			 </Style>
+			 <Style Selector="TabItem:selected">
+				 <Setter Property="Foreground" Value="{DynamicResource DockThemeForegroundBrush}"/>
+			 </Style>
+		 </TabControl.Styles>
       <TabItem Header="General Info">
         <ScrollViewer>
           <StackPanel Orientation="Vertical" Spacing="10">

--- a/UABEANext4/Views/Dialogs/AssetInfoView.axaml
+++ b/UABEANext4/Views/Dialogs/AssetInfoView.axaml
@@ -20,6 +20,11 @@
       <uac:AssetTypeIconConverter x:Key="TypeTreeNodeConverter" />
     </Grid.Resources>
     <TabControl Grid.Row="0">
+		  <TabControl.Styles>
+			  <Style Selector="TabItem">
+				  <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}"/>
+			  </Style>
+		  </TabControl.Styles>
       <TabItem Header="General Info">
         <ScrollViewer>
           <StackPanel Orientation="Vertical" Spacing="10">

--- a/UABEANext4/Views/MainWindow.axaml.cs
+++ b/UABEANext4/Views/MainWindow.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Platform.Storage;
 using System.Linq;
 using System.Threading.Tasks;
 using UABEANext4.ViewModels;
+using System.IO;
 #if DEBUG
 using Avalonia.Diagnostics;
 using UABEANext4.Logic.DevTools;
@@ -22,6 +23,23 @@ public partial class MainWindow : Window
         InitializeComponent();
 #endif
         AddHandler(DragDrop.DropEvent, Drop);
+
+        Opened += async (s, e) => await HandleCommandLineArgs();
+    }
+
+    private async Task HandleCommandLineArgs()
+    {
+        var args = System.Environment.GetCommandLineArgs();
+
+        var filePaths = args.Skip(1)
+            .Where(arg => !string.IsNullOrWhiteSpace(arg))
+            .Where(arg => File.Exists(arg))
+            .ToList();
+
+        if (filePaths.Any() && DataContext is MainViewModel viewModel)
+        {
+            await viewModel.OpenFiles(filePaths);
+        }
     }
 
     private async Task Drop(object? sender, DragEventArgs e)


### PR DESCRIPTION
This fixes text color for white theme here:
<img width="522" height="245" alt="AZPgWT0fLs" src="https://github.com/user-attachments/assets/50ec2fc8-0a29-4b33-be6b-40bde483cf44" />

And we have now:
<img width="493" height="220" alt="ts5uAOb3l5" src="https://github.com/user-attachments/assets/d2c63035-652b-4160-a8b6-6c8696a1ea24" />
<img width="452" height="221" alt="1RcgvKg94R" src="https://github.com/user-attachments/assets/9355f49a-517e-460f-b2d0-26f04d024232" />

This PR also adds drag&drop support for .exe files and for Open as in context menu. I know that drag&drop works when the program window is open; this is just an additional case.