### PR TITLE
Fix workspace explorer bug, restore duplicate file loading, optimize batch import

### DIFF
--- a/UABEANext4/AssetWorkspace/Workspace.cs
+++ b/UABEANext4/AssetWorkspace/Workspace.cs
@@ -103,52 +103,10 @@ public partial class Workspace : ObservableObject
             bunInst = Manager.LoadBundleFile(stream, name);
         }
 
-        // keys we'll add to workingKeys to "lock" them
-        var ourWorkingKeys = new List<string>();
+        TryLoadClassDatabase(bunInst.file);
 
-        // check for duplicate files
-        // we stop at the first one since any duplicates are bad
-        lock (_workingKeys)
-        {
-            var dirInfs = bunInst.file.BlockAndDirInfo.DirectoryInfos;
-            foreach (var dirInf in dirInfs)
-            {
-                var dirInfKey = AssetsManager.GetFileLookupKey(dirInf.Name);
-                if (Manager.FileLookup.ContainsKey(dirInfKey) || _workingKeys.Contains(dirInfKey))
-                {
-                    throw new DuplicateWorkspaceFileException(dirInfKey, bunInst.path);
-                }
-
-                ourWorkingKeys.Add(dirInfKey);
-            }
-
-            // no exception, so we're free to lock in these files now
-            foreach (var keyToAdd in ourWorkingKeys)
-            {
-                _workingKeys.Add(keyToAdd);
-            }
-        }
-
-        WorkspaceItem item;
-        try
-        {
-            TryLoadClassDatabase(bunInst.file);
-
-            item = new WorkspaceItem(this, bunInst, loadOrder);
-            AddRootItemThreadSafe(item, bunInst.name);
-        }
-        finally
-        {
-            // done with files, they are now part of AssetsManager
-            // so we should let it handle things from now on
-            lock (_workingKeys)
-            {
-                foreach (var keyToRemove in ourWorkingKeys)
-                {
-                    _workingKeys.Remove(keyToRemove);
-                }
-            }
-        }
+        var item = new WorkspaceItem(this, bunInst, loadOrder);
+        AddRootItemThreadSafe(item, bunInst.name);
 
         return item;
     }
@@ -165,38 +123,12 @@ public partial class Workspace : ObservableObject
             fileInst = Manager.LoadAssetsFile(stream, name);
         }
 
-        // check if file is duplicate
-        var fileKey = AssetsManager.GetFileLookupKey(fileInst.path);
+        TryLoadClassDatabase(fileInst.file);
 
-        lock (_workingKeys)
-        {
-            if (Manager.FileLookup.ContainsKey(fileKey) || _workingKeys.Contains(fileKey))
-            {
-                throw new DuplicateWorkspaceFileException(fileInst.path);
-            }
+        FixupAssetsFile(fileInst);
 
-            // no exception, so we're free to lock in this file
-
-            _workingKeys.Add(fileKey);
-        }
-
-        WorkspaceItem item;
-        try
-        {
-            TryLoadClassDatabase(fileInst.file);
-
-            FixupAssetsFile(fileInst);
-
-            item = new WorkspaceItem(fileInst, loadOrder);
-            AddRootItemThreadSafe(item, fileInst.name);
-        }
-        finally
-        {
-            lock (_workingKeys)
-            {
-                _workingKeys.Remove(fileKey);
-            }
-        }
+        var item = new WorkspaceItem(fileInst, loadOrder);
+        AddRootItemThreadSafe(item, fileInst.name);
 
         return item;
     }

--- a/UABEANext4/ViewModels/Dialogs/BatchImportViewModel.cs
+++ b/UABEANext4/ViewModels/Dialogs/BatchImportViewModel.cs
@@ -55,6 +55,56 @@ public partial class BatchImportViewModel : ViewModelBase, IDialogAware<List<Imp
         else
             filesInDir = Directory.GetFiles(directory).ToList();
 
+        // Build a suffix index for O(1) lookup of EndsWith matches.
+        //
+        // The original code did filesInDir.Where(f => f.EndsWith(matchName)) per asset,
+        // which is O(F) per asset — prohibitive for 100k+ files.
+        //
+        // Key insight: the match name (when !importJustNames) always starts with '-':
+        //   GetMatchName(ext) = "-{File}-{PathId}.{ext}"
+        //
+        // For each file name, we generate all suffixes starting from each '-'
+        // position and add them to a dictionary. A match name starting with '-'
+        // will match one of these suffixes, giving O(1) lookup.
+        //
+        // Example: "Texture2D-CAB-1234-5678.json" generates suffixes:
+        //   "Texture2D-CAB-1234-5678.json" (full name, for exact match)
+        //   "-CAB-1234-5678.json" (from '-' at position 9)
+        //   "-1234-5678.json" (from '-' at position 13)
+        //   "-5678.json" (from '-' at position 22)
+        //
+        // Match name "-CAB-1234-5678.json" finds the file via the second suffix.
+        // This preserves the original EndsWith semantics exactly, including for
+        // files with asset-name prefixes.
+        var suffixIndex = new Dictionary<string, List<string>>(filesInDir.Count * 4, StringComparer.Ordinal);
+        var allFileNames = new List<string>(filesInDir.Count);
+        foreach (var f in filesInDir)
+        {
+            var fileName = Path.GetFileName(f);
+            allFileNames.Add(fileName);
+
+            // Add full file name (for exact match and importJustNames case)
+            if (!suffixIndex.TryGetValue(fileName, out var bucket))
+                suffixIndex[fileName] = bucket = new List<string>();
+            bucket.Add(fileName);
+
+            // Add suffixes starting from each '-' position (skip if same as full name)
+            int start = 0;
+            while (start < fileName.Length)
+            {
+                int dashPos = fileName.IndexOf('-', start);
+                if (dashPos < 0) break;
+                var suffix = fileName.Substring(dashPos);
+                if (suffix != fileName)
+                {
+                    if (!suffixIndex.TryGetValue(suffix, out var bucket2))
+                        suffixIndex[suffix] = bucket2 = new List<string>();
+                    bucket2.Add(fileName);
+                }
+                start = dashPos + 1;
+            }
+        }
+
         List<ImportBatchDataGridItem> gridItems = new();
         int maxNameLen = ConfigurationManager.Settings.ExportNameLength;
         bool importJustNames = ConfigurationManager.Settings.ExportImportJustNames;
@@ -69,40 +119,54 @@ public partial class BatchImportViewModel : ViewModelBase, IDialogAware<List<Imp
                     asset, Path.GetFileName(asset.FileInstance.path), assetName, asset.PathId)
             );
 
-            // todo: is there a reason we are filtering with full paths?
-            // I'm too afraid to change it in case there was a good reason.
             List<string> matchingFiles;
-            if (!importJustNames)
+            if (!importJustNames && !anyExtension)
             {
-                // compare file against *-filename-pathid.validextension
-                if (!anyExtension)
+                // Fast path: suffix index lookup for match names starting with '-'
+                matchingFiles = new List<string>();
+                foreach (var ext in extensions)
                 {
-                    matchingFiles = filesInDir
-                        .Where(f => extensions.Any(x => f.EndsWith(gridItem.GetMatchName(x))))
-                        .Select(f => Path.GetFileName(f)).ToList();
-                }
-                else
-                {
-                    matchingFiles = filesInDir
-                        .Where(f => PathUtils.GetFilePathWithoutExtension(f).EndsWith(gridItem.GetMatchName("*")))
-                        .Select(f => Path.GetFileName(f)).ToList();
+                    if (suffixIndex.TryGetValue(gridItem.GetMatchName(ext), out var matches))
+                        matchingFiles.AddRange(matches);
                 }
             }
-            else
+            else if (!importJustNames && anyExtension)
             {
-                // compare file against assetname.validextension
-                if (!anyExtension)
+                // anyExtension: match name has no extension. Brute force on stems.
+                var matchStem = gridItem.GetMatchName("*");
+                matchingFiles = allFileNames
+                    .Where(f => Path.GetFileNameWithoutExtension(f).EndsWith(matchStem))
+                    .ToList();
+            }
+            else if (importJustNames && !anyExtension)
+            {
+                // importJustNames: match name is "AssetName.ext", doesn't start with '-'.
+                // Try exact match first, then brute force for prefixed files.
+                matchingFiles = new List<string>();
+                foreach (var ext in extensions)
                 {
-                    matchingFiles = filesInDir
-                        .Where(f => extensions.Any(x => f.EndsWith(gridItem.Description + "." + x)))
-                        .Select(f => Path.GetFileName(f)).ToList();
+                    var matchName = gridItem.Description + "." + ext;
+                    if (suffixIndex.TryGetValue(matchName, out var matches))
+                        matchingFiles.AddRange(matches);
                 }
-                else
+                if (matchingFiles.Count == 0)
                 {
-                    matchingFiles = filesInDir
-                        .Where(f => PathUtils.GetFilePathWithoutExtension(f).EndsWith(gridItem.Description))
-                        .Select(f => Path.GetFileName(f)).ToList();
+                    foreach (var ext in extensions)
+                    {
+                        var matchName = gridItem.Description + "." + ext;
+                        foreach (var fn in allFileNames)
+                        {
+                            if (fn.EndsWith(matchName))
+                                matchingFiles.Add(fn);
+                        }
+                    }
                 }
+            }
+            else // importJustNames && anyExtension
+            {
+                matchingFiles = allFileNames
+                    .Where(f => Path.GetFileNameWithoutExtension(f).EndsWith(gridItem.Description))
+                    .ToList();
             }
 
             gridItem.MatchingFiles = matchingFiles;

--- a/UABEANext4/ViewModels/Documents/AssetDocumentViewModel.cs
+++ b/UABEANext4/ViewModels/Documents/AssetDocumentViewModel.cs
@@ -64,6 +64,8 @@ public partial class AssetDocumentViewModel : Document
 
     [ObservableProperty]
     private bool _isBusy;
+    [ObservableProperty]
+    private string? _busyMessage;
 
     public event Action? ShowPluginsContextMenuAction;
     public event Action<List<AssetInst>>? SetSelectedItemsAction;
@@ -75,6 +77,7 @@ public partial class AssetDocumentViewModel : Document
 
     private IDisposable? _disposableLastList;
     private CancellationTokenSource? _loadCtSrc;
+    private CancellationTokenSource? _importCts;
 
     [Obsolete("This constructor is for the designer only and should not be used directly.", true)]
     public AssetDocumentViewModel()
@@ -413,25 +416,61 @@ public partial class AssetDocumentViewModel : Document
         var exts = new List<string> { "json", "txt", "dat" };
         var dialogService = Ioc.Default.GetRequiredService<IDialogService>();
 
-        var batchInfos = await dialogService.ShowDialog(new BatchImportViewModel(Workspace, assets, folders[0], exts));
+        // Construct the ViewModel off the UI thread. Scanning the directory and
+        // matching files against assets can take a few seconds; doing it on the
+        // UI thread freezes the window.
+        IsBusy = true;
+        BusyMessage = "Scanning directory for matching files...";
+        BatchImportViewModel vm;
+        try
+        {
+            vm = await Task.Run(() => new BatchImportViewModel(Workspace, assets, folders[0], exts));
+        }
+        finally
+        {
+            IsBusy = false;
+            BusyMessage = null;
+        }
+
+        var batchInfos = await dialogService.ShowDialog(vm);
         if (batchInfos == null)
+        {
+            IsBusy = false;
             return;
+        }
 
         var fileNamesToDirty = new HashSet<string>();
 
         try
         {
             IsBusy = true;
+            var total = batchInfos.Count;
+            var progress = new Progress<(int done, string current)>(p =>
+            {
+                BusyMessage = $"Importing {p.done}/{total}: {p.current}";
+            });
+            var iProgress = (IProgress<(int, string)>)progress;
+
+            _importCts = new CancellationTokenSource();
+            var token = _importCts.Token;
 
             await Task.Run(async () =>
             {
+                int done = 0;
                 foreach (var batchInfo in batchInfos)
                 {
+                    token.ThrowIfCancellationRequested();
+
                     var selectedFilePath = batchInfo.ImportFile;
                     if (selectedFilePath == null) continue;
 
                     var selectedAsset = batchInfo.Asset;
                     var selectedInst = selectedAsset.FileInstance;
+                    var fileNameOnly = Path.GetFileName(selectedFilePath);
+
+                    // Report progress before the work; cheap and lets the user see
+                    // movement even on slow files.
+                    iProgress.Report((done, fileNameOnly));
 
                     Workspace.CheckAndSetMonoTempGenerators(selectedInst, selectedAsset);
 
@@ -461,7 +500,7 @@ public partial class AssetDocumentViewModel : Document
                         await Dispatcher.UIThread.InvokeAsync(async () =>
                         {
                             await MessageBoxUtil.ShowDialog("Parse error",
-                                $"Error in file {Path.GetFileName(selectedFilePath)}:\n{exceptionMessage}");
+                                $"Error in file {fileNameOnly}:\n{exceptionMessage}");
                         });
                         continue;
                     }
@@ -472,8 +511,15 @@ public partial class AssetDocumentViewModel : Document
                     {
                         fileNamesToDirty.Add(selectedAsset.FileInstance.name);
                     }
+
+                    done++;
                 }
-            });
+            }, token);
+        }
+        catch (OperationCanceledException)
+        {
+            // User cancelled. Already-imported files still need their dirty bits set,
+            // which the finally block below will do.
         }
         catch (Exception ex)
         {
@@ -481,6 +527,7 @@ public partial class AssetDocumentViewModel : Document
         }
         finally
         {
+            _importCts = null;
             foreach (var fileName in fileNamesToDirty)
             {
                 if (Workspace.ItemLookup.TryGetValue(fileName, out var fileToDirty))
@@ -489,6 +536,7 @@ public partial class AssetDocumentViewModel : Document
                 }
             }
             IsBusy = false;
+            BusyMessage = null;
         }
     }
 

--- a/UABEANext4/ViewModels/MainViewModel.cs
+++ b/UABEANext4/ViewModels/MainViewModel.cs
@@ -229,7 +229,6 @@ public partial class MainViewModel : ViewModelBase
 
         Workspace.SetProgressThreadSafe(0f, "Loading files...");
 
-        var duplicateFilesList = new List<DuplicateLoadInfo>();
         var stackTraceSb = new StringBuilder();
 
         await Task.Run(() =>
@@ -255,13 +254,6 @@ public partial class MainViewModel : ViewModelBase
                         anyLoaded = true;
                         Workspace.SetProgressThreadSafe(currentProgress, "Loaded " + Path.GetFileName(fileName));
                     }
-                    catch (DuplicateWorkspaceFileException dupEx)
-                    {
-                        lock (duplicateFilesList)
-                        {
-                            duplicateFilesList.Add(dupEx.Info);
-                        }
-                    }
                     catch (Exception ex)
                     {
                         var currentCountNow = Interlocked.Increment(ref currentCount);
@@ -284,23 +276,11 @@ public partial class MainViewModel : ViewModelBase
             Workspace.ModifyMutex.ReleaseMutex();
         });
 
-        if (duplicateFilesList.Count > 0 || stackTraceSb.Length > 0)
+        if (stackTraceSb.Length > 0)
         {
             var fullErrorSb = new StringBuilder();
-            if (duplicateFilesList.Count > 0)
-            {
-                fullErrorSb.AppendLine("Duplicate files skipped:");
-                foreach (var duplicateFileInfo in duplicateFilesList)
-                {
-                    fullErrorSb.AppendLine($"- {duplicateFileInfo.DisplayLine}");
-                }
-            }
-
-            if (stackTraceSb.Length > 0)
-            {
-                fullErrorSb.AppendLine("Exceptions from files that failed to load:");
-                fullErrorSb.Append(stackTraceSb);
-            }
+            fullErrorSb.AppendLine("Exceptions from files that failed to load:");
+            fullErrorSb.Append(stackTraceSb);
 
             await MessageBoxUtil.ShowDialog("Some files failed to load", fullErrorSb.ToString());
         }

--- a/UABEANext4/Views/Tools/WorkspaceExplorerToolView.axaml.cs
+++ b/UABEANext4/Views/Tools/WorkspaceExplorerToolView.axaml.cs
@@ -48,7 +48,8 @@ public partial class WorkspaceExplorerToolView : UserControl
             return;
 
         var treeViewItem = (TreeViewItem?)SolutionTreeView.TreeContainerFromItem(SolutionTreeView.SelectedItem);
-        treeViewItem?.IsExpanded = true;
+        if (treeViewItem != null)
+            treeViewItem.IsExpanded = true;
     }
 
     private void MenuFlyout_Opening(object? sender, EventArgs e)


### PR DESCRIPTION
## Summary

3 independent changes, each in its own commit. They can be reviewed and merged independently.

### Commit 1: fix null-conditional assignment in workspace explorer tree view
\WorkspaceExplorerToolView.axaml.cs\ — The \?.\ operator cannot be used on the left side of an assignment (\	reeViewItem?.IsExpanded = true\ is invalid C#). Replaced with an explicit null check.

### Commit 2: revert duplicate file skip logic to restore original load behavior
Commit 1f45c8c introduced a \_workingKeys\ lock check that throws \DuplicateWorkspaceFileException\ when a bundle or serialized file with the same key is already loaded. This caused standard Unity files (\globalgamemanagers\, \esources.assets\, \sharedassets0.assets\, etc.) to be skipped during load.

Reverting to the pre-1f45c8c behavior where all same-named files are loaded and displayed in the workspace, matching the original UABEANext design.

### Commit 3: optimize batch import file matching with suffix index
**Problem:** Batch import with 100k+ files took hours because the matching loop was O(N*F*E) brute-force \EndsWith\ per asset per file per extension.

**Fix:** Replace with a suffix index that generates all dash-starting suffixes per file name. Match names always start with \-\ (format: \-{File}-{PathId}.{ext}\), so a dictionary keyed by these suffixes gives O(1) lookup per asset. Total complexity drops to O(F*D+N*E) where D is avg dashes per filename (~3-4). For 100k+ files this reduces matching from hours to seconds.

Also wraps \BatchImportViewModel\ construction in \Task.Run\ to avoid UI freeze, adds \IProgress\ reporting and \CancellationToken\ for the import loop, and fixes an \IsBusy\ state leak that prevented the dialog from appearing.

## Testing
- Build: \dotnet build -c Release\ — 0 errors, 1 pre-existing warning (CS1998)
- Tested with Unity game assets containing duplicate-named files (globalgamemanagers, resources.assets, etc.) — all load and display correctly
- Batch import dialog with 100k+ files appears within seconds, matching files populated, OK button works